### PR TITLE
Adjust chat env validation to allow optional prompt

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -75,7 +75,6 @@ export async function POST(req: NextRequest) {
     // 1. ENVIRONMENT VARIABLES VALIDATION
     const requiredEnvVars = {
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-      NEX_PROMPT_ID: process.env.NEX_PROMPT_ID,
       NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
       NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
       DATABASE_URL: process.env.DATABASE_URL
@@ -101,6 +100,10 @@ export async function POST(req: NextRequest) {
     }
     
     console.log(`✅ [Chat API] ${requestId} Environment variables validated`);
+
+    if (!process.env.NEX_PROMPT_ID) {
+      console.warn(`⚠️ [Chat API] ${requestId} Optional NEX_PROMPT_ID not configured – using default system prompt.`);
+    }
     
     // 2. AUTHENTICATION CHECK
     const token = await getToken({ req });

--- a/lib/env-validation.ts
+++ b/lib/env-validation.ts
@@ -9,7 +9,6 @@ export function validateEnvironmentVariables() {
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
-    NEX_PROMPT_ID: process.env.NEX_PROMPT_ID,
   };
 
   // Optional but recommended environment variables (warn if missing)
@@ -20,6 +19,7 @@ export function validateEnvironmentVariables() {
     GEMINI_API_KEY: process.env.GEMINI_API_KEY,
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
     VERCEL_API_KEY: process.env.VERCEL_API_KEY,
+    NEX_PROMPT_ID: process.env.NEX_PROMPT_ID,
   };
 
   const missing: string[] = [];


### PR DESCRIPTION
## Summary
- stop treating `NEX_PROMPT_ID` as a required environment variable for the chat API
- surface a warning when the optional prompt id is missing instead of failing requests
- update env validation to only warn about missing prompt ids

## Testing
- pnpm lint *(fails: existing lint warnings and react/no-unescaped-entities errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce812c2d9883278a9a7bfa9d1efb3b